### PR TITLE
Fix Pester version to 4.10.1

### DIFF
--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -134,10 +134,10 @@ task NuGet {
 
 # Synopsis: Install Pester module
 task Pester NuGet, {
-    if ($Null -eq (Get-InstalledModule -Name Pester -MinimumVersion 4.9.0 -ErrorAction Ignore)) {
-        Install-Module -Name Pester -MinimumVersion 4.9.0 -Scope CurrentUser -Force -SkipPublisherCheck;
+    if ($Null -eq (Get-InstalledModule -Name Pester -RequiredVersion 4.10.1 -ErrorAction Ignore)) {
+        Install-Module -Name Pester -RequiredVersion 4.10.1 -Scope CurrentUser -Force -SkipPublisherCheck;
     }
-    Import-Module -Name Pester -Verbose:$False;
+    Import-Module -Name Pester -RequiredVersion 4.10.1 -Verbose:$False;
 }
 
 # Synopsis: Install PSScriptAnalyzer module


### PR DESCRIPTION
## PR Summary

- Sets required Pester version to v4.10.1 instead of using latest version. #15 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [ ] [Change log](https://github.com/Microsoft/PSRule.Monitor/blob/master/CHANGELOG.md) has been updated with change under unreleased section
