### PR TITLE
Pre-release v0.3.0-B2108014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.3.0-B2108014 (pre-release)
+
 What's changed since pre-release v0.3.0-B2108008:
 
 - General improvements:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.3.0-B2108008:

- General improvements:
  - Added `Duration_d` that duration in milliseconds that the rule took to execute. #49

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
