### PR TITLE
Release v0.5.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Capture any error messages and or verbose messages with `-Verbose`.
 **Module in use and version:**
 
 - Module: PSRule.Monitor
-- Version: **[e.g. 0.1.0]**
+- Version: **[e.g. 0.5.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 - **Code changes**
   - [ ] Have unit tests created/ updated
   - [ ] Link to a filed issue
-  - [ ] [Change log](https://github.com/Microsoft/PSRule.Monitor/blob/main/CHANGELOG.md) has been updated with change under unreleased section
+  - [ ] [Change log](https://github.com/microsoft/PSRule.Monitor/blob/main/CHANGELOG.md) has been updated with change under unreleased section

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+## v0.5.0
+
+What's changed since v0.4.0:
+
+- Engineering:
+  - Bump PSRule to v2.3.2.
+    [#90](https://github.com/microsoft/PSRule.Monitor/pull/90)
+  - Bump Microsoft.PowerShell.SDK to v7.2.6.
+    [#80](https://github.com/microsoft/PSRule.Monitor/pull/80)
+  - Bump Microsoft.NET.Test.Sdk to v17.3.0.
+    [#79](https://github.com/microsoft/PSRule.Monitor/pull/79)
+  - Upgrade support projects to .NET 6 by @BernieWhite.
+    [#83](https://github.com/microsoft/PSRule.Monitor/issues/83)
+  - Automatically update PowerShell dependencies by @BernieWhite.
+    [#84](https://github.com/microsoft/PSRule.Monitor/issues/84)
+  - Update Pester tests to v5 by @BernieWhite.
+    [#15](https://github.com/microsoft/PSRule.Monitor/issues/15)
+  - Added code signing and SBOM metadata by @BernieWhite.
+    [#86](https://github.com/microsoft/PSRule.Monitor/issues/86)
+
+What's changed since pre-release v0.5.0-B0014:
+
+- No additional changes.
+
 ## v0.5.0-B0014 (pre-release)
 
 What's changed since pre-release v0.5.0-B0005:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 This project is [licensed under the MIT License](LICENSE).
 
 [install]: docs/scenarios/install-instructions.md
-[ci-badge]: https://dev.azure.com/bewhite/PSRule.Monitor/_apis/build/status/PSRule.Monitor-CI?branchName=main
 [module]: https://www.powershellgallery.com/packages/PSRule.Monitor
 [engine]: https://github.com/Microsoft/PSRule
 [issue]: https://github.com/Microsoft/PSRule.Monitor/issues


### PR DESCRIPTION
## PR Summary

What's changed since v0.4.0:

- Engineering:
  - Bump PSRule to v2.3.2.
    [#90](https://github.com/microsoft/PSRule.Monitor/pull/90)
  - Bump Microsoft.PowerShell.SDK to v7.2.6.
    [#80](https://github.com/microsoft/PSRule.Monitor/pull/80)
  - Bump Microsoft.NET.Test.Sdk to v17.3.0.
    [#79](https://github.com/microsoft/PSRule.Monitor/pull/79)
  - Upgrade support projects to .NET 6 by @BernieWhite.
    [#83](https://github.com/microsoft/PSRule.Monitor/issues/83)
  - Automatically update PowerShell dependencies by @BernieWhite.
    [#84](https://github.com/microsoft/PSRule.Monitor/issues/84)
  - Update Pester tests to v5 by @BernieWhite.
    [#15](https://github.com/microsoft/PSRule.Monitor/issues/15)
  - Added code signing and SBOM metadata by @BernieWhite.
    [#86](https://github.com/microsoft/PSRule.Monitor/issues/86)

What's changed since pre-release v0.5.0-B0014:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
