### PR TITLE
Pre-release v0.6.0-B0035

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.6.0-B0035 (pre-release)
+
 What's changed since pre-release v0.6.0-B0012:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.6.0-B0012:

- Engineering:
  - Bump PSRule to v2.8.1.
    [#126](https://github.com/microsoft/PSRule.Monitor/pull/126)
  - Bump Pester to v5.4.1.
    [#126](https://github.com/microsoft/PSRule.Monitor/pull/126)
  - Bump Microsoft.NET.Test.Sdk to v17.5.0.
    [#118](https://github.com/microsoft/PSRule.Monitor/pull/118)
  - Bump Newtonsoft.Json to v13.0.3.
    [#120](https://github.com/microsoft/PSRule.Monitor/pull/120)
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.1.
    [#121](https://github.com/microsoft/PSRule.Monitor/pull/121)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
